### PR TITLE
Automatically merge test profiles

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,3 @@
-(defproject lein-test-out "0.3.1"
+(defproject lein-test-out "0.3.2"
             :eval-in-leiningen true
             :dependencies [[org.clojure/tools.namespace "0.2.3"]])

--- a/src/leiningen/test_out.clj
+++ b/src/leiningen/test_out.clj
@@ -1,6 +1,6 @@
 (ns leiningen.test-out
+  (:require [leiningen.core.project])
   (:use [leiningen.core.eval :only [eval-in-project]]
-
         [clojure.tools.namespace :only [find-namespaces-in-dir]]))
 
 (try
@@ -48,11 +48,12 @@ Usage: lein test-out <format> <filename>
 
 By default, outputs junit XML to testreports.xml."
   [project & [format filename]]
-  (let [filename (or filename "testreports.xml")
+  (let [project-merged (leiningen.core.project/merge-profiles project [:leiningen/test :test])
+        filename (or filename "testreports.xml")
         forms [(require-clojure-test-form)
-               (run-form project format filename)]]
+               (run-form project-merged format filename)]]
     (eval-in-project
-     project
+     project-merged
      (second forms) ;; form
      ;nil ;; handler
      ;nil ;; skip-auto-compile


### PR DESCRIPTION
Port of https://github.com/arohner/lein-test-out/pull/9

When Leiningen runs its built-in 'test' command, it merges both the
`:test` and `:leiningen/test` profiles automatically [*]. If a project has
test-only configuration enabled under either of those profiles, simply
running `$ lein test-out ...` will fail. Rather, the user must manually
enable the needed profiles by running under 'with-profile'. This commit
automatically merges the same profiles that `lein test` does to maintain
compatibility without having to manually using 'with-profile'.

[*]
https://github.com/technomancy/leiningen/blob/90bf2d47cd0ef113ab6d1a498608a917d586ad6c/src/leiningen/test.clj#L192